### PR TITLE
Add low fire overlay option

### DIFF
--- a/src/client/java/pl/lordtricker/ltbpvp/client/config/Config.java
+++ b/src/client/java/pl/lordtricker/ltbpvp/client/config/Config.java
@@ -33,6 +33,9 @@ public class Config {
     public boolean armorStatusTextEnabled = true;
     public int armorStatusThreshold = 25;
 
+    public boolean lowFireEnabled = false;
+    public float lowFireHeight = 0.0f;
+
     public Map<SwingStyle, AnimationOffsets> styleOffsets = new EnumMap<>(SwingStyle.class);
 
     public boolean offhandAnimationEnabled = false;

--- a/src/client/java/pl/lordtricker/ltbpvp/client/config/ModSettings.java
+++ b/src/client/java/pl/lordtricker/ltbpvp/client/config/ModSettings.java
@@ -38,6 +38,9 @@ public class ModSettings {
     public static boolean armorStatusTextEnabled = true;
     public static int armorStatusThreshold = 25;
 
+    public static boolean lowFireEnabled = false;
+    public static float lowFireHeight = 0.0f;
+
     static {
         for (SwingStyle style : SwingStyle.values()) {
             styleOffsets.put(style, new AnimationOffsets(0.0f, 0.0f, 0.0f));
@@ -94,6 +97,8 @@ public class ModSettings {
         cfg.armorStatusSoundEnabled = armorStatusSoundEnabled;
         cfg.armorStatusTextEnabled = armorStatusTextEnabled;
         cfg.armorStatusThreshold = armorStatusThreshold;
+        cfg.lowFireEnabled = lowFireEnabled;
+        cfg.lowFireHeight = lowFireHeight;
         return cfg;
     }
 
@@ -123,6 +128,8 @@ public class ModSettings {
         armorStatusSoundEnabled = cfg.armorStatusSoundEnabled;
         armorStatusTextEnabled = cfg.armorStatusTextEnabled;
         armorStatusThreshold = cfg.armorStatusThreshold;
+        lowFireEnabled = cfg.lowFireEnabled;
+        lowFireHeight = cfg.lowFireHeight;
         for (SwingStyle style : cfg.styleOffsets.keySet()) {
             Config.AnimationOffsets coff = cfg.styleOffsets.get(style);
             AnimationOffsets moff = styleOffsets.get(style);

--- a/src/client/java/pl/lordtricker/ltbpvp/client/gui/LowFireEditorScreen.java
+++ b/src/client/java/pl/lordtricker/ltbpvp/client/gui/LowFireEditorScreen.java
@@ -1,0 +1,69 @@
+package pl.lordtricker.ltbpvp.client.gui;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.SliderWidget;
+import net.minecraft.text.Text;
+import pl.lordtricker.ltbpvp.client.config.ModSettings;
+
+public class LowFireEditorScreen extends Screen {
+    private final Screen parent;
+    private HeightSlider slider;
+
+    private static final int W = 150, H = 20, SPACE = 25;
+
+    public LowFireEditorScreen(Screen parent) {
+        super(Text.literal("Edit - Low Fire"));
+        this.parent = parent;
+    }
+
+    @Override
+    protected void init() {
+        int cx = this.width / 2;
+        int y  = (this.height - SPACE) / 2;
+
+        slider = new HeightSlider(cx - W / 2, y, W, H, ModSettings.lowFireHeight);
+        addDrawableChild(slider);
+
+        y += SPACE + 5;
+        ButtonWidget reset = ButtonWidget.builder(Text.of("Reset"), b -> {
+            ModSettings.lowFireHeight = 0f;
+            slider.setSliderValue(0f);
+        }).dimensions(cx - W / 2, y, W, H).build();
+        addDrawableChild(reset);
+
+        ButtonWidget save = ButtonWidget.builder(Text.of("Save"), b -> {
+            slider.applySlider();
+            this.client.setScreen(parent);
+        }).dimensions(cx - 50, this.height - 30, 100, H).build();
+        addDrawableChild(save);
+    }
+
+    @Override
+    public void render(DrawContext ctx, int mouseX, int mouseY, float delta) {
+        this.renderBackground(ctx, mouseX, mouseY, delta);
+        super.render(ctx, mouseX, mouseY, delta);
+        int w = this.textRenderer.getWidth(this.title);
+        ctx.drawText(this.textRenderer, this.title, (this.width - w) / 2, 10, 0xFFFFFF, false);
+    }
+
+    private static class HeightSlider extends SliderWidget {
+        HeightSlider(int x, int y, int w, int h, float height) {
+            super(x, y, w, h, Text.literal("Height: " + String.format("%.1f", height)), normalize(height));
+        }
+        @Override
+        protected void updateMessage() {
+            float val = denormalize(value);
+            this.setMessage(Text.literal("Height: " + String.format("%.1f", val)));
+        }
+        @Override
+        protected void applyValue() {
+            ModSettings.lowFireHeight = denormalize(value);
+        }
+        void applySlider() { applyValue(); }
+        void setSliderValue(float v) { this.value = normalize(v); updateMessage(); }
+        private static double normalize(float v) { return (v + 20.0) / 40.0; }
+        private static float denormalize(double v) { return (float)(v * 40.0 - 20.0); }
+    }
+}

--- a/src/client/java/pl/lordtricker/ltbpvp/client/gui/MainSettingsScreen.java
+++ b/src/client/java/pl/lordtricker/ltbpvp/client/gui/MainSettingsScreen.java
@@ -5,6 +5,7 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.text.Text;
 import pl.lordtricker.ltbpvp.client.config.ModSettings;
+import pl.lordtricker.ltbpvp.client.gui.LowFireEditorScreen;
 
 public class MainSettingsScreen extends Screen {
     private boolean animationsEnabled;
@@ -25,6 +26,9 @@ public class MainSettingsScreen extends Screen {
     private ButtonWidget armorToggleButton;
     private ButtonWidget armorEditButton;
 
+    private ButtonWidget lowFireToggleButton;
+    private ButtonWidget lowFireEditButton;
+
     private int rowHeight;
     private final int labelAreaWidth = 120;
     private final int buttonAreaWidth = 100;
@@ -44,8 +48,8 @@ public class MainSettingsScreen extends Screen {
         rowHeight = 25;
         int btnHeight = 20;
 
-        /* 8 wierszy - 0 tutor, 1 sword, 2 offhand, 3 cursor, 4 armor, 5 autojump, 6 bobbing, 7 shake */
-        int totalLines       = 8;
+        /* 9 wierszy - 0 tutor, 1 sword, 2 offhand, 3 cursor, 4 armor, 5 lowfire, 6 autojump, 7 bobbing, 8 shake */
+        int totalLines       = 9;
         int totalBlockHeight = totalLines * rowHeight;
         this.startY          = (this.height - totalBlockHeight) / 2;
 
@@ -146,6 +150,25 @@ public class MainSettingsScreen extends Screen {
         addDrawableChild(armorEditButton);
         armorEditButton.active = ModSettings.armorStatusEnabled;
 
+        /* --- Low Fire ---------------------------------------------- */
+        y += rowHeight;
+        lowFireToggleButton = ButtonWidget.builder(
+                Text.of(getToggleDisplay(ModSettings.lowFireEnabled)),
+                btn -> {
+                    ModSettings.lowFireEnabled = !ModSettings.lowFireEnabled;
+                    btn.setMessage(Text.of(getToggleDisplay(ModSettings.lowFireEnabled)));
+                    lowFireEditButton.active = ModSettings.lowFireEnabled;
+                }
+        ).dimensions(buttonX, y, 80, btnHeight).build();
+        addDrawableChild(lowFireToggleButton);
+
+        lowFireEditButton = ButtonWidget.builder(
+                Text.of("..."),
+                btn -> this.client.setScreen(new LowFireEditorScreen(this))
+        ).dimensions(buttonX + 80, y, 20, btnHeight).build();
+        addDrawableChild(lowFireEditButton);
+        lowFireEditButton.active = ModSettings.lowFireEnabled;
+
         /* --- Minecraft‑owe przełączniki (auto‑jump, bobbing, shake) */
         MinecraftSettingsWidget mc = new MinecraftSettingsWidget();
         y += rowHeight;
@@ -188,9 +211,10 @@ public class MainSettingsScreen extends Screen {
         ctx.drawText(this.textRenderer, "OffHand Animation:",   labelX, startY + 2 * rowHeight + 5, 0xFFFFFF, false);
         ctx.drawText(this.textRenderer, "Cursor ESP:",          labelX, startY + 3 * rowHeight + 5, 0xFFFFFF, false);
         ctx.drawText(this.textRenderer, "Armor status:",        labelX, startY + 4 * rowHeight + 5, 0xFFFFFF, false);
-        ctx.drawText(this.textRenderer, "Auto Jump:",           labelX, startY + 5 * rowHeight + 5, 0xFFFFFF, false);
-        ctx.drawText(this.textRenderer, "View Bobbing:",        labelX, startY + 6 * rowHeight + 5, 0xFFFFFF, false);
-        ctx.drawText(this.textRenderer, "Screen Shake:",        labelX, startY + 7 * rowHeight + 5, 0xFFFFFF, false);
+        ctx.drawText(this.textRenderer, "Low Fire:",            labelX, startY + 5 * rowHeight + 5, 0xFFFFFF, false);
+        ctx.drawText(this.textRenderer, "Auto Jump:",           labelX, startY + 6 * rowHeight + 5, 0xFFFFFF, false);
+        ctx.drawText(this.textRenderer, "View Bobbing:",        labelX, startY + 7 * rowHeight + 5, 0xFFFFFF, false);
+        ctx.drawText(this.textRenderer, "Screen Shake:",        labelX, startY + 8 * rowHeight + 5, 0xFFFFFF, false);
     }
 
     private void drawCenteredTextLocal(DrawContext ctx, Text text, int y, int color) {

--- a/src/client/java/pl/lordtricker/ltbpvp/client/mixin/LowFireMixin.java
+++ b/src/client/java/pl/lordtricker/ltbpvp/client/mixin/LowFireMixin.java
@@ -1,0 +1,28 @@
+package pl.lordtricker.ltbpvp.client.mixin;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.hud.InGameHud;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import pl.lordtricker.ltbpvp.client.config.ModSettings;
+
+@Mixin(InGameHud.class)
+public class LowFireMixin {
+
+    @Inject(method = "renderFireOverlay", at = @At("HEAD"))
+    private void onRenderFireOverlayHead(DrawContext ctx, CallbackInfo ci) {
+        if (ModSettings.lowFireEnabled) {
+            ctx.getMatrices().push();
+            ctx.getMatrices().translate(0.0F, ModSettings.lowFireHeight, 0.0F);
+        }
+    }
+
+    @Inject(method = "renderFireOverlay", at = @At("RETURN"))
+    private void onRenderFireOverlayTail(DrawContext ctx, CallbackInfo ci) {
+        if (ModSettings.lowFireEnabled) {
+            ctx.getMatrices().pop();
+        }
+    }
+}

--- a/src/client/resources/ltbpvp.client.mixins.json
+++ b/src/client/resources/ltbpvp.client.mixins.json
@@ -5,10 +5,11 @@
 	"mixins": [
 		"AttackDelayTutorHudMixin",
 		"AttackDelayTutorMixin",
-		"CustomHandMixin",
-		"TargetCrosshairMixin",
-		"ArmorStatusMixin"
-	],
+                "CustomHandMixin",
+                "TargetCrosshairMixin",
+                "ArmorStatusMixin",
+                "LowFireMixin"
+        ],
 	"injectors": {
 		"defaultRequire": 1
 	}


### PR DESCRIPTION
## Summary
- implement configurable low fire effect
- add mixin for shifting fire overlay
- provide GUI editor with slider
- expose toggle/edit buttons in the main settings screen

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684adde60dc08324a48462877d97257f