### PR TITLE
Fix mixin array init

### DIFF
--- a/src/client/java/pl/lordtricker/ltbpvp/client/mixin/ArmorStatusMixin.java
+++ b/src/client/java/pl/lordtricker/ltbpvp/client/mixin/ArmorStatusMixin.java
@@ -19,7 +19,7 @@ public abstract class ArmorStatusMixin {
     @Unique private static final long COOLDOWN_MS = 5_000;
 
     /** Znacznik czasu ostatniego alarmu per slot. */
-    @Unique private final long[] lastAlert = {0, 0, 0, 0};
+    @Unique private final long[] lastAlert = new long[4];
 
     @Inject(method = "tick", at = @At("TAIL"))
     private void onClientTick(CallbackInfo ci) {


### PR DESCRIPTION
## Summary
- adjust `ArmorStatusMixin` to avoid unsupported LASTORE opcodes in class initializer

## Testing
- `./gradlew build` *(fails: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6873aa2c40608324a86fa0847410e3cb